### PR TITLE
chore: add C++ faker library

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Open source projects that use `@faker-js/faker` as a dependency. You can go to t
 
 ## Languages
 
+- [C++ - faker-cxx](https://github.com/cieslarmichal/faker-cxx) - C++ Faker library for generating fake (but realistic) data. 
 - [Java - java-faker](https://github.com/DiUS/java-faker) - Brings the popular ruby faker gem to Java.
 - [JavaScript - @faker-js/faker](https://github.com/faker-js/faker) - Generate massive amounts of fake data in the browser and node.js.
 - [Perl - Data-Faker](https://metacpan.org/dist/Data-Faker)


### PR DESCRIPTION
Adds a link to the c++ faker library:

- https://github.com/cieslarmichal/faker-cxx