### PR TITLE
feat: add data-generator app to the projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Open source projects that use `@faker-js/faker` as a dependency. You can go to t
 - [automatisch](https://github.com/automatisch/automatisch) - The open source Zapier alternative. Build workflow automation without spending time and money.
 - [CodeceptJS](https://github.com/codeceptjs/CodeceptJS) - Supercharged End 2 End Testing Framework for NodeJS.
 - [data](https://github.com/mswjs/data) - Data modeling and relation library for testing JavaScript applications.
+- [data-generator](https://github.com/BreisOne/data-generator) - A Next.js UI built with Shadcn and Tailwind CSS, designed as a wrapper for Faker.js to generate custom synthetic datasets. Include features to export data to CSV, JSON, and SQL.
 - [electrodb](https://github.com/tywalch/electrodb) - A DynamoDB library to ease the use of modeling complex hierarchical relationships and implementing a Single Table Design while keeping your query code readable.
 - [ember-cli-mirage](https://github.com/miragejs/ember-cli-mirage) - An Ember Addon to easily add Mirage JS to your Ember app.
 - [eui](https://github.com/elastic/eui) - Elastic UI Framework.
@@ -69,7 +70,6 @@ Open source projects that use `@faker-js/faker` as a dependency. You can go to t
 - [wave-ui](https://github.com/antoniandre/wave-ui) - A UI framework for Vue.js (2 & 3) with only the bright side.
 - [zod-plugins](https://github.com/anatine/zod-plugins) - Plugins and utilities for Zod.
 - [zui](https://github.com/easysoft/zui) - ZUI is an HTML5 front UI framework.
-- [data-generator](https://github.com/BreisOne/data-generator) - A Next.js UI built with Shadcn and Tailwind CSS, designed as a wrapper for Faker.js to generate custom synthetic datasets. Include features to export data to CSV, JSON, and SQL.
 
 ## Services (SAAS or Commercial)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Open source projects that use `@faker-js/faker` as a dependency. You can go to t
 - [wave-ui](https://github.com/antoniandre/wave-ui) - A UI framework for Vue.js (2 & 3) with only the bright side.
 - [zod-plugins](https://github.com/anatine/zod-plugins) - Plugins and utilities for Zod.
 - [zui](https://github.com/easysoft/zui) - ZUI is an HTML5 front UI framework.
+- [data-generator](https://github.com/BreisOne/data-generator) - A Next.js UI built with Shadcn and Tailwind CSS, designed as a wrapper for Faker.js to generate custom synthetic datasets. Include features to export data to CSV, JSON, and SQL.
 
 ## Services (SAAS or Commercial)
 


### PR DESCRIPTION
added to the list the repo project “data-generator” a wrapper of faker.js in next.js that allows to generate the test dataset to the user and export them in multiple formats (csv, json, sql).